### PR TITLE
Add the ability to specify a regex for init_checks so only the matching checks will be added.

### DIFF
--- a/lib/pingdom-to-graphite/version.rb
+++ b/lib/pingdom-to-graphite/version.rb
@@ -1,3 +1,3 @@
 module PingdomToGraphite
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
This patch allows you to give a regex to init_checks so that you can pull a subset of checks instead of the whole shebang.  This functionality is handy for us since we have one graphite server per site and we only wanted to graph the specific site's checks.

So doing `pingdom-to-graphite init_checks "^DAL12 "`  would only pull in checks tagged DAL12.
