### PR TITLE
Remove Pingdom::Check from hardcoded metric prefix for Librato compat

### DIFF
--- a/lib/pingdom-to-graphite/cli.rb
+++ b/lib/pingdom-to-graphite/cli.rb
@@ -276,8 +276,8 @@ class PingdomToGraphite::CLI < Thor
   # Take a pingdom check, and return an Array of metrics to be passed to graphite
   def parse_result(check_id, result)
     results = Array.new
-    prefix = @config["graphite"]["prefix"] + "."
-    prefix += @checks[check_id.to_i].name.gsub(/ /,'_').gsub(/\./,'')
+    prefix = @config["graphite"]["prefix"] || "pingdom.Pingdom::Check"
+    prefix += ".#{@checks[check_id.to_i].name.gsub(/ /,'_').gsub(/\./,'')}"
     check_status = result.status.eql?("up") ? 1 : 0
     check_time = Time.at(result.time).to_i
     check_city = @probes[result.probe_id].city.gsub(/ /,"_").gsub(/\./,"")

--- a/lib/pingdom-to-graphite/cli.rb
+++ b/lib/pingdom-to-graphite/cli.rb
@@ -51,7 +51,7 @@ class PingdomToGraphite::CLI < Thor
         "graphite"  => {
           "host"  => "YOUR_SERVER",
           "port"    => "2003",
-          "prefix"  => "pingdom"
+          "prefix"  => "pingdom.Pingdom::Check"
         }
       }
       File.open(File.expand_path(options.config),"w",0600) do |f|
@@ -276,8 +276,8 @@ class PingdomToGraphite::CLI < Thor
   # Take a pingdom check, and return an Array of metrics to be passed to graphite
   def parse_result(check_id, result)
     results = Array.new
-    prefix = "#{@config["graphite"]["prefix"]}.#{@checks[check_id.to_i].class}."
-    prefix += @checks[check_id.to_i].name.gsub(/ /,"_").gsub(/\./,"")
+    prefix = @config["graphite"]["prefix"] + "."
+    prefix += @checks[check_id.to_i].name.gsub(/ /,'_').gsub(/\./,'')
     check_status = result.status.eql?("up") ? 1 : 0
     check_time = Time.at(result.time).to_i
     check_city = @probes[result.probe_id].city.gsub(/ /,"_").gsub(/\./,"")


### PR DESCRIPTION
Librato does not accept : character in a metric.  Remove it from the
hardcoded metric path and add it to the example config so users could
add it back and maintain backwards compat with this existing metric
paths.